### PR TITLE
Fixes to studyroom form validation

### DIFF
--- a/modules/studyroom_reservation/studyroom_reservation.admin.inc
+++ b/modules/studyroom_reservation/studyroom_reservation.admin.inc
@@ -276,12 +276,12 @@ function studyroom_reservation_edit_form($form, &$form_state, $entity, $space = 
     }
 
     // Set default date/time for existing date input and multidate input
-    $lang = $form['field_reservation_datetime']['#language'];
+    $lang = isset($form['field_reservation_datetime']['#language']) ? $form['field_reservation_datetime']['#language'] : 'und';
     $form['field_reservation_datetime'][$lang][0]['#default_value']['value'] = $date_time->format('Y-m-d h:i a');
   }
 
   if ($studyroom_reservation_type->type == 'faculty' || $studyroom_reservation_type->type == 'admin') {
-    $lang_multi = $form['field_multi_reservation_date_tim']['#language'];
+    $lang_multi = isset($form['field_multi_reservation_date_tim']['#language']) ? $form['field_multi_reservation_date_tim']['#language'] : 'und';
     $form['field_multi_reservation_date_tim'][$lang_multi][0]['#default_value']['value'] = $date_time->format('Y-m-d h:i a');
 
     $multi_day_location_list = get_long_term_faculty_focus_rooms();
@@ -416,7 +416,7 @@ function studyroom_reservation_edit_form_validate(&$form, &$form_state) {
   // Also check if there is a reservation id passed in. If so, treat as a single date and skip any multi-date input.
   if (($entity->type == 'faculty' || $entity->type == 'admin') && empty($entity->reservation_id) && $space_allows_multiday) {
     // gets the variable set in the array so it can be referenced. Usually set to something like 'und'
-    $multi_res_lang = $form['field_multi_reservation_date_tim']['#language'];
+    $multi_res_lang = isset($form['field_multi_reservation_date_tim']['#language']) ? $form['field_multi_reservation_date_tim']['#language'] : 'und';
 
     // if multi day options were requested, set multi-date to true
     if (isset($values['field_multi_reservation_date_tim'][$multi_res_lang][0]['rrule']) && $values['field_multi_reservation_date_tim'][$multi_res_lang][0]['rrule'] !== NULL) {
@@ -434,7 +434,7 @@ function studyroom_reservation_edit_form_validate(&$form, &$form_state) {
   } else {
     // reservation type is  not faculty or admin and will not have multi-dates.
     // Treat as a traditional reservation and get the value from the older input, but set it as a single index array so it can be processed the same as multi-date.
-    $langcode = $form['field_reservation_datetime']['#language'];
+    $langcode = isset($form['field_reservation_datetime']['#language']) ? $form['field_reservation_datetime']['#language'] : 'und';
     $resv_date_array = $values['field_reservation_datetime'][$langcode];
     $tz = $form['field_reservation_datetime'][$langcode][0]['#date_timezone'];
   }


### PR DESCRIPTION
Adding check that the #language key exists instead of assuming value is there.